### PR TITLE
df-quantile docs: add missing "0.75" to default quantiles description

### DIFF
--- a/private/statistics.rkt
+++ b/private/statistics.rkt
@@ -78,7 +78,7 @@
 
 ;; Return the quantiles for the series COLUMN in the dataframe DF.  A list of
 ;; quantiles is returned as specified by QVALUES, or if no quantiles are
-;; specified, the list (0 0.25 0.5 1) is used. #:weight-series has the usual
+;; specified, the list (0 0.25 0.5 0.75 1) is used. #:weight-series has the usual
 ;; meaning, #:less-than is the ordering function passed to the `quantile`
 ;; function.
 (define (df-quantile df column

--- a/scribblings/data-frame.scrbl
+++ b/scribblings/data-frame.scrbl
@@ -603,7 +603,7 @@ defined for the data frame, see @racket[df-set-default-weight-series].
 Return the quantiles for the @racket[series] in the data frame
 @racket[df].  A list of quantiles is returned as specified by
 @racket[qvalue], or if no quantiles are specified, the list @racket[(0
-0.25 0.5 1)] is used. @racket[#:weight-series] has the usual meaning,
+0.25 0.5 0.75 1)] is used. @racket[#:weight-series] has the usual meaning,
 @racket[less-than] is the ordering function passed to the
 @racket[quantile] function.
 


### PR DESCRIPTION
This brings the docs for `df-quantile` into agreement on the default quantiles in the code