### PR TITLE
Some more getters

### DIFF
--- a/private/bsearch.rkt
+++ b/private/bsearch.rkt
@@ -21,61 +21,153 @@
 (require racket/contract
          racket/math)
 
-;; Search a sorted vector, VEC for a value VAL.  The vector is assumed to
-;; contain sorted values, as defined by CMP-FN.  KEY, if present, selects the
-;; value to compare (useful if the vector contains structures and we want to
-;; search on a structure slot).  START and END define the sub-range of the
-;; vector to search.
+;; Both `lower-bound` and `upper-bound` will search a sorted vector, VEC for a
+;; value VAL and return an index into the vector.  The vector is assumed to
+;; contain sorted values, as defined by CMP-FN (which must define a strict
+;; ordering, that is a "less than" operation, BUT NOT a "less than or equal"
+;; operation).  KEY, if present, selects the value to compare (useful if the
+;; vector contains structures and we want to search on a structure slot).
+;; START and END define the sub-range of the vector to search.
 ;;
-;; bsearch will return an index identifying the position where VAL could be
-;; inserted to keep the range sorted.  That is:
+;; If unsure, you need to use `lower-bound`
 ;;
-;; * if VAl exists in the vector, its location is returned
+;; `lower-bound` will return an index identifying the earliest position where
+;; VAL could be inserted to keep the range sorted, while upper-bound will
+;; return the last position where an insertion would keep the value sorted.
 ;;
-;; * if VAL is smaller than the first value in the range, START is returned
+;; * if VAl exists one or more times in the vector, `lower-bound` will return
+;; the first occurrence, but `upper-bound` will return one after the last
+;; occurrence.  For example:
 ;;
-;; * if VAL is greater than the last value in the range, END is returned (this
-;; is considered out of range for the vector)
+;;     (define data (vector 1 2 3 4 5))
+;;     (lower-bound data 3) => 2 (position of '3' is at index 2)
+;;     (upper-bound data 3) => 3
 ;;
-;; * otherwise, an index is returned representing the location of VAL in the
-;; vector (or the "best" location, if val is not found).
+;;     (define data (vector 1 2 3 3 3 4 5))
+;;     (lower-bound data 3) => 2 (first '3' is at index 2)
+;;     (upper-bound data 3) => 5 (NOTE: at index 5 we have the value '4')
 ;;
-;; NOTE: this works like the std::lower_bound() function in C++.
-(define (bsearch vec val
-                 #:cmp (cmp-fn <)
-                 #:key (key-fn values)
-                 #:start (start 0)
-                 #:stop (end (vector-length vec)))
+;; * if VAL is smaller than the first value in the range, both functions
+;; return START
+;;
+;; * if VAL is greater than the last value in the range, both functions return
+;; END (this is considered out of range for the vector)
+;;
+;; * If VAL does not exist, an index is returned representing the location of
+;; VAL in the vector (or the "best" location, if val is not found).  Same
+;; index is returned by both functions.
+;;
+;; To determine if a value actually exists in a vector you also need to check
+;; the actual value at the position returned by `lower-bound`, like so:
+;;
+;; (define (exists? data v)
+;;   (define index (lower-bound data v))
+;;   (and (< index (vector-length data))
+;;        (equal? v (vector-ref data index))))
+;;
+;; NOTE: this works like the std::lower_bound() and std::upper_bound()
+;; functions in C++.
 
-  (define (do-search start end)
+(define (lower-bound vec val
+                     #:cmp (cmp-fn <)
+                     #:key (key-fn values)
+                     #:start (start 0)
+                     #:stop (end (vector-length vec)))
+
+  (let ((vlen (vector-length vec)))
+    (cond ((or (< start 0) (> start vlen))
+           (raise-range-error 'lower-bound "vector" "starting " start vec 0 vlen))
+          ((or (< end 0) (> end vlen))
+           (raise-range-error 'lower-bound "vector" "ending " end vec 0 vlen))
+          ((> start end)
+           (raise-range-error
+            'lower-bound "vector" "ending " end vec start vlen 0))))
+
+  (let loop ([start start]
+             [end end])
+    (if (= start end)
+        start
+        (let* ((mid (exact-truncate (/ (+ start end) 2)))
+               (mid-val (key-fn (vector-ref vec mid))))
+          (if (cmp-fn mid-val val)
+              (loop (add1 mid) end)
+              (loop start mid))))))
+
+(define (upper-bound vec val
+                     #:cmp (cmp-fn <)
+                     #:key (key-fn values)
+                     #:start (start 0)
+                     #:stop (end (vector-length vec)))
+
+  (let ((vlen (vector-length vec)))
+    (cond ((or (< start 0) (> start vlen))
+           (raise-range-error 'upper-bound "vector" "starting " start vec 0 vlen))
+          ((or (< end 0) (> end vlen))
+           (raise-range-error 'upper-bound "vector" "ending " end vec 0 vlen))
+          ((> start end)
+           (raise-range-error
+            'upper-bound "vector" "ending " end vec start vlen 0))))
+
+  (let loop ([start start]
+             [end end])
     (if (= start end)
         start
         (let* ((mid (exact-truncate (/ (+ start end) 2)))
                (mid-val (key-fn (vector-ref vec mid))))
           (if (cmp-fn val mid-val)
-              (do-search start mid)
-              (if (cmp-fn mid-val val)
-                  (do-search (+ mid 1) end)
-                  mid)))))
+              (loop start mid)
+              (loop (add1 mid) end))))))
+
+;; Return two values representing the start and one-plus end ranges where VAL
+;; is present in the sorted vector VEC.  This is equivalent to calling
+;; lower-bound and upper-bound with the same parameters, but will run somewhat
+;; faster
+(define (equal-range vec val
+                     #:cmp (cmp-fn <)
+                     #:key (key-fn values)
+                     #:start (start 0)
+                     #:stop (end (vector-length vec)))
 
   (let ((vlen (vector-length vec)))
     (cond ((or (< start 0) (> start vlen))
-           (raise-range-error 'bsearch "vector" "starting " start vec 0 vlen))
+           (raise-range-error 'equal-range "vector" "starting " start vec 0 vlen))
           ((or (< end 0) (> end vlen))
-           (raise-range-error 'bsearch "vector" "ending " end vec 0 vlen))
+           (raise-range-error 'equal-range "vector" "ending " end vec 0 vlen))
           ((> start end)
            (raise-range-error
-            'bsearch "vector" "ending " end vec start vlen 0))))
-
-  (do-search start end))
+            'equal-range "vector" "ending " end vec start vlen 0))))
+  
+  (define lb (lower-bound vec val #:cmp cmp-fn #:key key-fn #:start start #:stop end))
+  (cond ((>= lb end) (values lb lb))
+        ((equal? (vector-ref vec lb) val)
+         (values lb
+                 (upper-bound vec val #:cmp cmp-fn #:key key-fn #:start lb #:stop end)))
+        (#t
+         (values lb lb))))
 
 
 ;;............................................................. provides ....
 
 (provide/contract
- (bsearch (->* ((vectorof any/c) any/c)
-               (#:cmp (-> any/c any/c boolean?)
-                #:key (-> any/c any/c)
-                #:start integer?
-                #:stop integer?)
-               integer?)))
+ (lower-bound (->* ((vectorof any/c) any/c)
+                   (#:cmp (-> any/c any/c boolean?)
+                    #:key (-> any/c any/c)
+                    #:start integer?
+                    #:stop integer?)
+                   integer?))
+
+ (upper-bound (->* ((vectorof any/c) any/c)
+                   (#:cmp (-> any/c any/c boolean?)
+                    #:key (-> any/c any/c)
+                    #:start integer?
+                    #:stop integer?)
+                   integer?))
+
+ (equal-range (->* ((vectorof any/c) any/c)
+                   (#:cmp (-> any/c any/c boolean?)
+                    #:key (-> any/c any/c)
+                    #:start integer?
+                    #:stop integer?)
+                   (values integer? integer?)))
+
+ )

--- a/private/bsearch.rkt
+++ b/private/bsearch.rkt
@@ -85,7 +85,6 @@
 
   (let loop ([start start]
              [end end])
->>>>>>> upstream/ah/lower-bound
     (if (= start end)
         start
         (let* ((mid (exact-truncate (/ (+ start end) 2)))
@@ -94,30 +93,11 @@
               (loop (add1 mid) end)
               (loop start mid))))))
 
-define (upper-bound vec val
+(define (upper-bound vec val
                      #:cmp (cmp-fn <)
                      #:key (key-fn values)
                      #:start (start 0)
                      #:stop (end (vector-length vec)))
-
-  (define (do-reverse-search start end)
-    ; retain equality or else we end up with issues
-    (define (not-cmpfn a b)
-      ; if cmp-fn and equal? are true, this predicate respects equal?, and its negation
-      ; should too. (like <= and >=)
-      (define respect-equal? (and (equal? a b) (cmp-fn a b)))
-      (or (and respect-equal? (equal? a b))
-          (not (cmp-fn a b))))
-
-    (if (= start end)
-        (sub1 start)
-        (let* ((mid (exact-truncate (/ (+ start end) 2)))
-               (mid-val (key-fn (vector-ref vec mid))))
-          (if (not-cmpfn val mid-val)
-              (do-reverse-search (add1 mid) end)
-              (if (not-cmpfn mid-val val)
-                  (do-reverse-search start mid)
-                  mid)))))
 
   (let ((vlen (vector-length vec)))
     (cond ((or (< start 0) (> start vlen))
@@ -136,7 +116,7 @@ define (upper-bound vec val
                (mid-val (key-fn (vector-ref vec mid))))
           (if (cmp-fn val mid-val)
               (loop start mid)
-              (loop (add1 mid) end)))))
+              (loop (add1 mid) end))))))
 
 ;; Return two values representing the start and one-plus end ranges where VAL
 ;; is present in the sorted vector VEC.  This is equivalent to calling
@@ -156,7 +136,7 @@ define (upper-bound vec val
           ((> start end)
            (raise-range-error
             'equal-range "vector" "ending " end vec start vlen 0))))
-  
+
   (define lb (lower-bound vec val #:cmp cmp-fn #:key key-fn #:start start #:stop end))
   (cond ((>= lb end) (values lb lb))
         ((equal? (vector-ref vec lb) val)
@@ -188,5 +168,6 @@ define (upper-bound vec val
                     #:key (-> any/c any/c)
                     #:start integer?
                     #:stop integer?)
-                   (values integer? integer?))))
+                   (values integer? integer?)))
 
+ )

--- a/private/df.rkt
+++ b/private/df.rkt
@@ -284,9 +284,9 @@
 ;; If SERIES is not sorted, this will raise an error. This will return a pair of the
 ;; leftmost and rightmost index in the given series, in case the value is duplicated.
 ;; All other behavior is similar to or the same as df-index-of.
-(define (df-index-range df series value)
+(define (df-equal-range df series value)
   (let ([s (df-get-series df series)])
-    (series-index-range s value)))
+    (series-equal-range s value)))
 
 ;; Return the value at INDEX for SERIES.
 (define (df-ref df index series)
@@ -568,7 +568,7 @@
  (df-is-sorted? (-> data-frame? string? boolean?))
  (df-index-of (-> data-frame? string? any/c index/c))
  (df-index-of* (->* (data-frame? string?) #:rest list? (listof index/c)))
- (df-index-range (-> data-frame? string? any/c (values index/c index/c)))
+ (df-equal-range (-> data-frame? string? any/c (values index/c index/c)))
  (df-ref (-> data-frame? index/c string? any/c))
  (df-set! (-> data-frame? index/c any/c string? any/c))
  (df-ref* (->* (data-frame? index/c) #:rest (listof string?) vector?))

--- a/private/df.rkt
+++ b/private/df.rkt
@@ -248,6 +248,12 @@
         val)
       (for/vector #:length (- stop start) ([item sequence]) (list->vector item))))
 
+;; Determines if the given SERIES in the data frame DF is sorted. Useful for
+;; knowing when df-index-of is possible.
+(define (df-is-sorted? df series)
+  (let ([s (df-get-series df series)])
+    (series-is-sorted? s)))
+
 ;; Return the index (position) of VALUE in the data frame SERIES.  If SERIES
 ;; is not sorted, this will raise an error.  VALUE might not be present in the
 ;; series, in that case, the returned index is the position of the first
@@ -552,6 +558,7 @@
                      (#:start index/c #:stop index/c)
                      #:rest (listof string?)
                      sequence?))
+ (df-is-sorted? (-> data-frame? string? boolean?))
  (df-index-of (-> data-frame? string? any/c index/c))
  (df-index-of* (->* (data-frame? string?) #:rest list? (listof index/c)))
  (df-index-range (-> data-frame? string? any/c (cons/c index/c index/c)))

--- a/private/df.rkt
+++ b/private/df.rkt
@@ -267,6 +267,14 @@
   (let ([s (df-get-series df series)])
     (for/list ([v (in-list values)]) (series-index-of s v))))
 
+;; Return the indices (position) of VALUE in the data frame DF in the given SERIES.
+;; If SERIES is not sorted, this will raise an error. This will return a pair of the
+;; leftmost and rightmost index in the given series, in case the value is duplicated.
+;; All other behavior is similar to or the same as df-index-of.
+(define (df-index-range df series value)
+  (let ([s (df-get-series df series)])
+    (series-index-range s value)))
+
 ;; Return the value at INDEX for SERIES.
 (define (df-ref df index series)
   (let ([s (df-get-series df series)])
@@ -546,6 +554,7 @@
                      sequence?))
  (df-index-of (-> data-frame? string? any/c index/c))
  (df-index-of* (->* (data-frame? string?) #:rest list? (listof index/c)))
+ (df-index-range (-> data-frame? string? any/c (cons/c index/c index/c)))
  (df-ref (-> data-frame? index/c string? any/c))
  (df-set! (-> data-frame? index/c any/c string? any/c))
  (df-ref* (->* (data-frame? index/c) #:rest (listof string?) vector?))

--- a/private/df.rkt
+++ b/private/df.rkt
@@ -68,6 +68,13 @@
    (make-hash)
    (hash-copy properties)))
 
+;; Creates a copy of the series SERIES in the data frame DF. The returned copy
+;; will reference the same internal elements as the original, but any blessing
+;; operations or additions/deletions will only affect the copy.
+(define (df-duplicate-series df series)
+  (let ([s (df-get-series df series)])
+    (series-shallow-copy s)))
+
 ;; Return the series names in the data frame DF, as a list of strings.  The
 ;; names are returned in an unspecified order.
 (define (df-series-names df)
@@ -587,6 +594,7 @@
  (df-set-contract! (-> data-frame? string? (or/c #f (-> any/c boolean?)) any/c))
  (df-count-na (-> data-frame? string? exact-nonnegative-integer?))
  (df-shallow-copy (-> data-frame? data-frame?))
+ (df-duplicate-series (-> data-frame? string? series?))
  (df-is-na? (-> data-frame? string? any/c boolean?))
  (df-has-na? (-> data-frame? string? boolean?))
  (df-has-non-na? (-> data-frame? string? boolean?))

--- a/private/df.rkt
+++ b/private/df.rkt
@@ -568,7 +568,7 @@
  (df-is-sorted? (-> data-frame? string? boolean?))
  (df-index-of (-> data-frame? string? any/c index/c))
  (df-index-of* (->* (data-frame? string?) #:rest list? (listof index/c)))
- (df-index-range (-> data-frame? string? any/c (cons/c index/c index/c)))
+ (df-index-range (-> data-frame? string? any/c (values index/c index/c)))
  (df-ref (-> data-frame? index/c string? any/c))
  (df-set! (-> data-frame? index/c any/c string? any/c))
  (df-ref* (->* (data-frame? index/c) #:rest (listof string?) vector?))

--- a/private/df.rkt
+++ b/private/df.rkt
@@ -73,7 +73,7 @@
 ;; operations or additions/deletions will only affect the copy.
 (define (df-duplicate-series df series)
   (let ([s (df-get-series df series)])
-    (series-shallow-copy s)))
+    (copy-series s)))
 
 ;; Return the series names in the data frame DF, as a list of strings.  The
 ;; names are returned in an unspecified order.

--- a/private/scatter.rkt
+++ b/private/scatter.rkt
@@ -39,11 +39,11 @@
     (define lookup-val
       (+ (key-fn (vector-ref data-series start-index))
          amount))
-    (define index (bsearch data-series lookup-val #:key key-fn))
-    ;; NOTE: `bsearch` will return 0 if `lookup-val` is smaller than the first
-    ;; item in the vector, so we need one extra check in that case, so we drop
-    ;; values from the start of the series if the shift is beyond the start of
-    ;; the series.
+    (define index (lower-bound data-series lookup-val #:key key-fn))
+    ;; NOTE: `lower-bound` will return 0 if `lookup-val` is smaller than the
+    ;; first item in the vector, so we need one extra check in that case, so
+    ;; we drop values from the start of the series if the shift is beyond the
+    ;; start of the series.
     (if (and (< index (vector-length data-series))
              (or (> index 0)
                  (>= lookup-val (key-fn (vector-ref data-series 0)))))

--- a/private/series.rkt
+++ b/private/series.rkt
@@ -61,7 +61,7 @@
     (define vprev (if (> index beg) (vector-ref data (sub1 index)) #f))
     (cond ((equal? v na)
            (df-raise "check-valid-sort: ~a contains NA / values @~a" name index))
-          ((and (> index beg) (not (cmpfn vprev v)))
+          ((and (> index beg) (not (or (equal? vprev v) (cmpfn vprev v))))
            (df-raise "check-valid-sort: ~a not really sorted @~a (~a vs ~a)"
                      name index vprev v)))))
 
@@ -282,8 +282,7 @@
 (define (series-index-range c value)
   (match-define (series name data beg end cmpfn _ _) c)
   (if cmpfn
-      (cons (bsearch data value #:cmp cmpfn #:start beg #:stop end)
-            (bsearch data value #:cmp cmpfn #:start beg #:stop end #:rightmost? #t))
+      (equal-range data value #:cmp cmpfn #:start beg #:stop end)
       (df-raise (format "series-index-range: ~a is not sorted" name))))
 
 ;; Return the number of "not available" values in the data series.
@@ -336,8 +335,8 @@
                             exact-integer?)
                  sequence?))
  (series-index-of (-> series? any/c (or/c #f exact-nonnegative-integer?)))
- (series-index-range (-> series? any/c (or/c #f (cons/c exact-nonnegative-integer?
-                                                        exact-nonnegative-integer?))))
+ (series-index-range (-> series? any/c (values (or/c #f exact-nonnegative-integer?)
+                                               (or/c #f exact-nonnegative-integer?))))
  (series-bless-sorted (-> series? (or/c #f (-> any/c any/c boolean?)) any/c))
  (series-bless-contract (-> series? (or/c #f (-> any/c boolean?)) any/c))
  (series-na-count (-> series? exact-nonnegative-integer?))

--- a/private/series.rkt
+++ b/private/series.rkt
@@ -204,6 +204,12 @@
     (check-valid-sort c cmpfn))
   (set-series-cmpfn! c cmpfn))
 
+;; Checks if the given series C is sorted (so it has a comparison function,
+;; as if it had one and was not sorted, this would be a construction time
+;; error).
+(define (series-is-sorted? c)
+  (and (series-cmpfn c) #t))
+
 ;; Mark the data series C as having the CONTRACTFN contract.  All elements
 ;; will be validated with the contract first and an error will be raised if
 ;; they don't satisfy the contract.
@@ -311,6 +317,7 @@
  (series-size (-> series? exact-nonnegative-integer?))
  (series-empty? (-> series? boolean?))
  (series-is-na? (-> series? any/c boolean?))
+ (series-is-sorted? (-> series? boolean?))
  (series-free-space (-> series? exact-nonnegative-integer?))
  (series-reserve-space (-> series? exact-nonnegative-integer? any/c))
  (series-ref (-> series? exact-nonnegative-integer? any/c))

--- a/private/series.rkt
+++ b/private/series.rkt
@@ -257,7 +257,7 @@
 (define (series-index-of c value)
   (match-define (series name data beg end cmpfn _ _) c)
   (if cmpfn
-      (bsearch data value #:cmp cmpfn #:start beg #:stop end)
+      (lower-bound data value #:cmp cmpfn #:start beg #:stop end)
       (df-raise (format "series-index-of: ~a is not sorted" name))
       #;(for/first ([(x index) (in-indexed (in-vector data beg end))]
                     #:when (equal? x value))

--- a/private/series.rkt
+++ b/private/series.rkt
@@ -276,11 +276,11 @@
 ;; Find the first and last indices (multiple) of VALUE in the data series C.
 ;; The series has to be sorted, otherwise an error is raised. All other results
 ;; are the same as series-index-of.
-(define (series-index-range c value)
+(define (series-equal-range c value)
   (match-define (series name data beg end cmpfn _ _) c)
   (if cmpfn
       (equal-range data value #:cmp cmpfn #:start beg #:stop end)
-      (df-raise (format "series-index-range: ~a is not sorted" name))))
+      (df-raise (format "series-equal-range: ~a is not sorted" name))))
 
 ;; Return the number of "not available" values in the data series.
 (define (series-na-count c)
@@ -332,7 +332,7 @@
                             exact-integer?)
                  sequence?))
  (series-index-of (-> series? any/c (or/c #f exact-nonnegative-integer?)))
- (series-index-range (-> series? any/c (values (or/c #f exact-nonnegative-integer?)
+ (series-equal-range (-> series? any/c (values (or/c #f exact-nonnegative-integer?)
                                                (or/c #f exact-nonnegative-integer?))))
  (series-bless-sorted (-> series? (or/c #f (-> any/c any/c boolean?)) any/c))
  (series-bless-contract (-> series? (or/c #f (-> any/c boolean?)) any/c))

--- a/private/series.rkt
+++ b/private/series.rkt
@@ -263,6 +263,16 @@
                     #:when (equal? x value))
           index)))
 
+;; Find the first and last indices (multiple) of VALUE in the data series C.
+;; The series has to be sorted, otherwise an error is raised. All other results
+;; are the same as series-index-of.
+(define (series-index-range c value)
+  (match-define (series name data beg end cmpfn _ _) c)
+  (if cmpfn
+      (cons (bsearch data value #:cmp cmpfn #:start beg #:stop end)
+            (bsearch data value #:cmp cmpfn #:start beg #:stop end #:rightmost? #t))
+      (df-raise (format "series-index-range: ~a is not sorted" name))))
+
 ;; Return the number of "not available" values in the data series.
 (define (series-na-count c)
   (match-define (series _ data beg end _ na _) c)
@@ -311,6 +321,8 @@
                             exact-integer?)
                  sequence?))
  (series-index-of (-> series? any/c (or/c #f exact-nonnegative-integer?)))
+ (series-index-range (-> series? any/c (or/c #f (cons/c exact-nonnegative-integer?
+                                                        exact-nonnegative-integer?))))
  (series-bless-sorted (-> series? (or/c #f (-> any/c any/c boolean?)) any/c))
  (series-bless-contract (-> series? (or/c #f (-> any/c boolean?)) any/c))
  (series-na-count (-> series? exact-nonnegative-integer?))

--- a/private/series.rkt
+++ b/private/series.rkt
@@ -156,6 +156,13 @@
     (check-valid-sort df cmpfn))
   df)
 
+;; Creates a copy of the series C. The returned copy will reference the same
+;; elements as the original, but any add/delete operations and blessings
+;; will only affect the copy.
+(define (series-shallow-copy c)
+  (match-define (series name data beg end cmpfn na contractfn) c)
+  (series name (vector-copy data) beg end cmpfn na contractfn))
+
 ;; Return the number of elements in the series C.
 (define (series-size c)
   (- (series-end c) (series-beg c)))
@@ -311,6 +318,7 @@
                     #:na any/c
                     #:contract (-> any/c boolean?))
                    series?))
+ (series-shallow-copy (-> series? series?))
  (series? (-> any/c boolean?))
  (series-na (-> series? any/c))
  (series-name (-> series? string?))

--- a/private/series.rkt
+++ b/private/series.rkt
@@ -156,12 +156,9 @@
     (check-valid-sort df cmpfn))
   df)
 
-;; Creates a copy of the series C. The returned copy will reference the same
-;; elements as the original, but any add/delete operations and blessings
-;; will only affect the copy.
-(define (series-shallow-copy c)
-  (match-define (series name data beg end cmpfn na contractfn) c)
-  (series name (vector-copy data) beg end cmpfn na contractfn))
+;; Creates a copy of the series C.
+(define (copy-series c)
+  (struct-copy series c [data (vector-copy (series-data c))]))
 
 ;; Return the number of elements in the series C.
 (define (series-size c)
@@ -317,7 +314,7 @@
                     #:na any/c
                     #:contract (-> any/c boolean?))
                    series?))
- (series-shallow-copy (-> series? series?))
+ (copy-series (-> series? series?))
  (series? (-> any/c boolean?))
  (series-na (-> series? any/c))
  (series-name (-> series? string?))

--- a/private/test/df-test.rkt
+++ b/private/test/df-test.rkt
@@ -350,14 +350,14 @@
        (check equal? low 7)
        (check equal? upr 10))
 
-     (define c4 (series-shallow-copy c2))
+     (define c4 (copy-series c2))
      (check-false (equal? c2 c4))
      (check-true (equal? (series-name c2) (series-name c4)))
      (check-true (for/and ([a (in-series c2)] [b (in-series c4)])
                    (equal? a b)))
      (check-false (series-is-sorted? c4))
 
-     (check-true (series-is-sorted? (series-shallow-copy c3))))))
+     (check-true (series-is-sorted? (copy-series c3))))))
 
 
 ;;............................................................... spline ....

--- a/private/test/df-test.rkt
+++ b/private/test/df-test.rkt
@@ -267,7 +267,16 @@
 
      (check equal? (series-index-range c3 1) (cons 0 2))
      (check equal? (series-index-range c3 2) (cons 3 6))
-     (check equal? (series-index-range c3 3) (cons 7 9)))))
+     (check equal? (series-index-range c3 3) (cons 7 9))
+
+     (define c4 (series-shallow-copy c2))
+     (check-false (equal? c2 c4))
+     (check-true (equal? (series-name c2) (series-name c4)))
+     (check-true (for/and ([a (in-series c2)] [b (in-series c4)])
+                   (equal? a b)))
+     (check-false (series-is-sorted? c4))
+
+     (check-true (series-is-sorted? (series-shallow-copy c3))))))
 
 
 ;;............................................................... spline ....
@@ -578,6 +587,7 @@
       (lambda ()
         ;; wrong sort order
         (df-set-sorted! df "col6" >)))
+     ;; attempting sorting with wrong sort order didn't destroy the previous sorting
      (check-true (df-is-sorted? df "col6"))
 
      (define c7 (make-series "col7"
@@ -585,6 +595,7 @@
                              #:contract integer? #:cmpfn <=))
      (df-add-series! df c7)
 
+     (check-true (df-is-sorted? df "col7"))
      (check equal? (df-index-of df "col7" 1) 0)
      (check equal? (df-index-range df "col7" 1) (cons 0 1))
      (check equal? (df-index-of df "col7" 2) 2)

--- a/private/test/df-test.rkt
+++ b/private/test/df-test.rkt
@@ -66,7 +66,7 @@
 
 ;;.............................................................. bsearch ....
 
-define lower+upper-bound-tests
+(define lower+upper-bound-tests
   (test-suite
 
    "lower-bound/upper-bound"
@@ -111,7 +111,7 @@ define lower+upper-bound-tests
        (check equal? high 19))
 
      )
-     
+
    (test-case "reverse order"
      (define data (for/vector ([x (in-range 20 1 -1)]) x))
 
@@ -209,10 +209,7 @@ define lower+upper-bound-tests
       exn:fail:contract?
       (lambda ()
         ;; start is after end
-        (upper-bound data 5 #:start 5 #:stop 1)))
-
-
-     
+        (upper-bound data 5 #:start 5 #:stop 1))))))
 
 
 ;;................................................................ series ....
@@ -269,8 +266,12 @@ define lower+upper-bound-tests
      (check equal? (for/list ((x (in-series c2))) x) '(1 2 3 5))
 
      (check equal? (series-index-of c2 3) 2)
-     (check equal? (series-index-range c2 1) (cons 0 0))
-     (check equal? (series-index-range c2 3) (cons 2 2))
+     (let-values ([(low upr) (series-index-range c2 1)])
+       (check equal? low 0)
+       (check equal? upr 1))
+     (let-values ([(low upr) (series-index-range c2 3)])
+       (check equal? low 2)
+       (check equal? upr 3))
 
      (check-not-exn
       (lambda ()
@@ -337,11 +338,17 @@ define lower+upper-bound-tests
      (check equal? (series-ref c2 3) #f)
      (check equal? (series-na-count c2) 1) ; C2 has one NA value
 
-     (define c3 (make-series "c3" #:data #(1 1 1 2 2 2 2 3 3 3) #:cmpfn <=))
+     (define c3 (make-series "c3" #:data #(1 1 1 2 2 2 2 3 3 3) #:cmpfn <))
 
-     (check equal? (series-index-range c3 1) (cons 0 2))
-     (check equal? (series-index-range c3 2) (cons 3 6))
-     (check equal? (series-index-range c3 3) (cons 7 9))
+     (let-values ([(low upr) (series-index-range c3 1)])
+       (check equal? low 0)
+       (check equal? upr 3))
+     (let-values ([(low upr) (series-index-range c3 2)])
+       (check equal? low 3)
+       (check equal? upr 7))
+     (let-values ([(low upr) (series-index-range c3 3)])
+       (check equal? low 7)
+       (check equal? upr 10))
 
      (define c4 (series-shallow-copy c2))
      (check-false (equal? c2 c4))
@@ -596,7 +603,9 @@ define lower+upper-bound-tests
      (check = (df-index-of df "col1" -1) 0)
      (check = (df-index-of df "col1" 100) 4)
      (check equal? (df-index-of* df "col1" 2 -1 100) '(1 0 4))
-     (check equal? (df-index-range df "col1" 2) (cons 1 1))
+     (let-values ([(low upr) (df-index-range df "col1" 2)])
+       (check equal? low 1)
+       (check equal? upr 2))
 
      ;; col1: 1 2 3 4; col2: 3 2 1 0
      (check equal? (df-lookup df "col1" "col2" 3) 1)
@@ -666,14 +675,18 @@ define lower+upper-bound-tests
 
      (define c7 (make-series "col7"
                              #:data #(1 1 2 2)
-                             #:contract integer? #:cmpfn <=))
+                             #:contract integer? #:cmpfn <))
      (df-add-series! df c7)
 
      (check-true (df-is-sorted? df "col7"))
      (check equal? (df-index-of df "col7" 1) 0)
-     (check equal? (df-index-range df "col7" 1) (cons 0 1))
+     (let-values ([(low upr) (df-index-range df "col7" 1)])
+       (check equal? low 0)
+       (check equal? upr 2))
      (check equal? (df-index-of df "col7" 2) 2)
-     (check equal? (df-index-range df "col7" 2) (cons 2 3))
+     (let-values ([(low upr) (df-index-range df "col7" 2)])
+       (check equal? low 2)
+       (check equal? upr 4))
 
      (check-not-exn
       (lambda ()

--- a/private/test/df-test.rkt
+++ b/private/test/df-test.rkt
@@ -266,10 +266,10 @@
      (check equal? (for/list ((x (in-series c2))) x) '(1 2 3 5))
 
      (check equal? (series-index-of c2 3) 2)
-     (let-values ([(low upr) (series-index-range c2 1)])
+     (let-values ([(low upr) (series-equal-range c2 1)])
        (check equal? low 0)
        (check equal? upr 1))
-     (let-values ([(low upr) (series-index-range c2 3)])
+     (let-values ([(low upr) (series-equal-range c2 3)])
        (check equal? low 2)
        (check equal? upr 3))
 
@@ -340,13 +340,13 @@
 
      (define c3 (make-series "c3" #:data #(1 1 1 2 2 2 2 3 3 3) #:cmpfn <))
 
-     (let-values ([(low upr) (series-index-range c3 1)])
+     (let-values ([(low upr) (series-equal-range c3 1)])
        (check equal? low 0)
        (check equal? upr 3))
-     (let-values ([(low upr) (series-index-range c3 2)])
+     (let-values ([(low upr) (series-equal-range c3 2)])
        (check equal? low 3)
        (check equal? upr 7))
-     (let-values ([(low upr) (series-index-range c3 3)])
+     (let-values ([(low upr) (series-equal-range c3 3)])
        (check equal? low 7)
        (check equal? upr 10))
 
@@ -603,7 +603,7 @@
      (check = (df-index-of df "col1" -1) 0)
      (check = (df-index-of df "col1" 100) 4)
      (check equal? (df-index-of* df "col1" 2 -1 100) '(1 0 4))
-     (let-values ([(low upr) (df-index-range df "col1" 2)])
+     (let-values ([(low upr) (df-equal-range df "col1" 2)])
        (check equal? low 1)
        (check equal? upr 2))
 
@@ -680,11 +680,11 @@
 
      (check-true (df-is-sorted? df "col7"))
      (check equal? (df-index-of df "col7" 1) 0)
-     (let-values ([(low upr) (df-index-range df "col7" 1)])
+     (let-values ([(low upr) (df-equal-range df "col7" 1)])
        (check equal? low 0)
        (check equal? upr 2))
      (check equal? (df-index-of df "col7" 2) 2)
-     (let-values ([(low upr) (df-index-range df "col7" 2)])
+     (let-values ([(low upr) (df-equal-range df "col7" 2)])
        (check equal? low 2)
        (check equal? upr 4))
 

--- a/private/test/df-test.rkt
+++ b/private/test/df-test.rkt
@@ -165,6 +165,7 @@
      (check-true (series-empty? c1))
      (series-reserve-space c1 100)
      (check = (series-free-space c1) 100)
+     (check-false (series-is-sorted? c1))
 
      ;; NOTE: c1 is empty
      (check-false (series-has-non-na? c1))
@@ -188,6 +189,7 @@
 
      (check-false (series-has-na? c2))
      (check-true (series-has-non-na? c2))
+     (check-true (series-is-sorted? c2))
 
      (check equal? (for/list ((x (in-series c1))) x) '())
      (check equal? (for/list ((x (in-series c2))) x) '(1 2 3 5))
@@ -326,6 +328,7 @@
       (lambda ()
         (df-add-series! df c1)))
      (check equal? (df-count-na df "col1") 0)
+     (check-true (df-is-sorted? df "col1"))
      (define c2 (make-series "col2" #:data #(3 2 1 0) #:contract integer? #:cmpfn >))
      (check-not-exn
       (lambda ()
@@ -565,14 +568,17 @@
 
      (define c6 (make-series "col6" #:data #(1 2 3 4) #:contract integer?))
      (df-add-series! df c6)
+     (check-false (df-is-sorted? df "col6"))
      (check-not-exn
       (lambda ()
         (df-set-sorted! df "col6" <)))
+     (check-true (df-is-sorted? df "col6"))
      (check-exn
       exn:fail:data-frame?
       (lambda ()
         ;; wrong sort order
         (df-set-sorted! df "col6" >)))
+     (check-true (df-is-sorted? df "col6"))
 
      (define c7 (make-series "col7"
                              #:data #(1 1 2 2)

--- a/private/test/df-test.rkt
+++ b/private/test/df-test.rkt
@@ -65,63 +65,150 @@
 
 ;;.............................................................. bsearch ....
 
-(define bsearch-tests
+(define lower+upper-bound-tests
   (test-suite
 
-   "bsearch"
+   "lower-bound/upper-bound"
 
-   (test-case "bsearch: empty vector"
+   (test-case "empty vector"
      (define empty (make-vector 0))
-     (check equal? (bsearch empty 5) 0))
-     
-   (test-case "bsearch: reverse order"
-     (define rdata (for/vector ([x (in-range 20 1 -1)]) x))
-     (check equal? (bsearch rdata 5 #:cmp >) 15))
+     (check equal? (lower-bound empty 5) 0)
+     (check equal? (upper-bound empty 5) 0))
 
-   (test-case "bsearch: other"
+   (test-case "distinct values"
+     (define data (for/vector ([x (in-range 1 20)]) x))
+
+     ;; An existing value
+     (check equal? (lower-bound data 5) 4)
+     (check equal? (upper-bound data 5) 5)
+
+     (let-values ([(low high) (equal-range data 5)])
+       (check equal? low 4)
+       (check equal? high 5))
+
+     ;; A non-existent value, somewhere inside the vector range
+     (check equal? (lower-bound data 4.5) 4)
+     (check equal? (upper-bound data 4.5) 4)
+
+     (let-values ([(low high) (equal-range data 4.5)])
+       (check equal? low 4)
+       (check equal? high 4))
+
+     ;; Non Existent value before the first value in the vector
+     (check equal? (lower-bound data -1) 0)
+     (check equal? (upper-bound data -1) 0)
+
+     (let-values ([(low high) (equal-range data -1)])
+       (check equal? low 0)
+       (check equal? high 0))
+
+     ;; Non Existent value after the last value in the vector
+     (check equal? (lower-bound data 100) 19)
+     (check equal? (upper-bound data 100) 19)
+     (let-values ([(low high) (equal-range data 100)])
+       (check equal? low 19)
+       (check equal? high 19))
+
+     )
+     
+   (test-case "reverse order"
+     (define data (for/vector ([x (in-range 20 1 -1)]) x))
+
+     ;; An existing value
+     (check equal? (lower-bound data 5 #:cmp >) 15)
+     (check equal? (upper-bound data 5 #:cmp >) 16)
+     (let-values ([(low high) (equal-range data 5 #:cmp >)])
+       (check equal? low 15)
+       (check equal? high 16))
+
+     ;; A non-existent value, somewhere inside the vector range
+     (check equal? (lower-bound data 4.5 #:cmp >) 16)
+     (check equal? (upper-bound data 4.5 #:cmp >) 16)
+     (let-values ([(low high) (equal-range data 4.5 #:cmp >)])
+       (check equal? low 16)
+       (check equal? high 16))
+
+     ;; Non Existent value before the first value in the vector
+     (check equal? (lower-bound data -1 #:cmp >) 19)
+     (check equal? (upper-bound data -1 #:cmp >) 19)
+     (let-values ([(low high) (equal-range data -1 #:cmp >)])
+       (check equal? low 19)
+       (check equal? high 19))
+
+     ;; Non Existent value after the last value in the vector
+     (check equal? (lower-bound data 100 #:cmp >) 0)
+     (check equal? (upper-bound data 100 #:cmp >) 0)
+     (let-values ([(low high) (equal-range data 100 #:cmp >)])
+       (check equal? low 0)
+       (check equal? high 0)))
+
+   (test-case "duplicate values"
+     (define data (vector 1 2 3 3 3 4 5 6))
+
+     ;; An existing value
+     (check equal? (lower-bound data 3) 2)
+     (check equal? (upper-bound data 3) 5)
+     (let-values ([(low high) (equal-range data 3)])
+       (check equal? low 2)
+       (check equal? high 5)))
+
+   (test-case "other"
      (define data (for/vector ([x (in-range 1 21)]) x)) ; 20 element vector
 
-     ;; Simple search
-     (check equal? (bsearch data 5) 4)
-     ;; Search for out of range values
-     (check equal? (bsearch data -1) 0)
-     (check equal? (bsearch data 25) 20)
-     ;; Search for values that are at the end of the range
-     (check equal? (bsearch data 1) 0)
-     (check equal? (bsearch data 20) 19)
-     ;; Search for inexact values -- the best place will be found
-     (check equal? (bsearch data 0.9) 0)
-     (check equal? (bsearch data 1.1) 1)
-     (check equal? (bsearch data 18.9) 18)
-
      ;; Sub-range searching, basics
-     (check equal? (bsearch data 5 #:start 0 #:stop 3) 3)
-     (check equal? (bsearch data 5 #:start 3 #:stop 7) 4)
-     (check equal? (bsearch data 5 #:stop 3) 3)
-     (check equal? (bsearch data 5 #:start 7) 7)
+     (check equal? (lower-bound data 5 #:start 0 #:stop 3) 3)
+     (check equal? (lower-bound data 5 #:start 3 #:stop 7) 4)
+     (check equal? (lower-bound data 5 #:stop 3) 3)
+     (check equal? (lower-bound data 5 #:start 7) 7)
+
+     (check equal? (upper-bound data 5 #:start 0 #:stop 3) 3)
+     (check equal? (upper-bound data 5 #:start 3 #:stop 7) 5)
+     (check equal? (upper-bound data 5 #:stop 3) 3)
+     (check equal? (upper-bound data 5 #:start 7) 7)
 
      ;; Searches in ranges of 1 and 0 length ranges
-     (check equal? (bsearch data 5 #:start 4 #:stop 5) 4)
-     (check equal? (bsearch data 5 #:start 3 #:stop 3) 3)
+     (check equal? (lower-bound data 5 #:start 4 #:stop 5) 4)
+     (check equal? (lower-bound data 5 #:start 3 #:stop 3) 3)
+
+     (check equal? (upper-bound data 5 #:start 4 #:stop 5) 5)
+     (check equal? (upper-bound data 5 #:start 3 #:stop 3) 3)
 
      ;; ;; Off the grid searches
      (check-exn
       exn:fail:contract?
       (lambda ()
         ;; start is out of range, should raise exception
-        (bsearch data 5 #:start -100 #:stop 5)))
+        (lower-bound data 5 #:start -100 #:stop 5)))
+
+     (check-exn
+      exn:fail:contract?
+      (lambda ()
+        ;; start is out of range, should raise exception
+        (upper-bound data 5 #:start -100 #:stop 5)))
 
      (check-exn
       exn:fail:contract?
       (lambda ()
         ;; end is out of range, should raise exception
-        (bsearch data 5 #:start 0 #:stop 200)))
+        (lower-bound data 5 #:start 0 #:stop 200)))
+
+     (check-exn
+      exn:fail:contract?
+      (lambda ()
+        ;; end is out of range, should raise exception
+        (upper-bound data 5 #:start 0 #:stop 200)))
+     
+     (check-exn
+      exn:fail:contract?
+      (lambda ()
+        ;; start is after end
+        (lower-bound data 5 #:start 5 #:stop 1)))
 
      (check-exn
       exn:fail:contract?
       (lambda ()
         ;; start is after end
-        (bsearch data 5 #:start 5 #:stop 1)))
+        (upper-bound data 5 #:start 5 #:stop 1)))
 
      )))
 
@@ -1068,7 +1155,7 @@
   (require al2-test-runner)
   (run-tests #:package "data-frame"
              #:results-file "test-results-data-frame.xml"
-             bsearch-tests
+             lower+upper-bound-tests
              series-tests
              spline-tests
              df-tests

--- a/private/test/df-test.rkt
+++ b/private/test/df-test.rkt
@@ -350,6 +350,16 @@
        (check equal? low 7)
        (check equal? upr 10))
 
+     (let-values ([(low upr) (series-equal-range c3 1.5)])
+       (check equal? low 3)
+       (check equal? upr 3))
+     (let-values ([(low upr) (series-equal-range c3 2.3)])
+       (check equal? low 7)
+       (check equal? upr 7))
+     (let-values ([(low upr) (series-equal-range c3 2.7)])
+       (check equal? low 7)
+       (check equal? upr 7))
+
      (define c4 (copy-series c2))
      (check-false (equal? c2 c4))
      (check-true (equal? (series-name c2) (series-name c4)))

--- a/scribblings/data-frame.scrbl
+++ b/scribblings/data-frame.scrbl
@@ -115,6 +115,13 @@ the data series, except NA values must satisfy this contract.
 
 }
 
+@defproc[(df-shallow-copy [df data-frame?]) data-frame]{
+  Creates a copy of @racket[df]. The returned copy will reference the
+  same data series objects as the original (and the properties), but any
+  add/delete operations, for both series and properties, will only affect
+  the copy.
+}
+
 @defproc[(df-add-series! (df data-frame?) (series series?)) any/c]{
 Add a new series to the data frame.  If the data frame is empty, the
 series can have any number of elements, otherwise it must have the
@@ -441,6 +448,20 @@ or equal than the first value of the series and a value of
 @racket[(df-row-count df)] is returned if the value is greater than
 all the values in @racket[series].
 
+}
+
+@defproc[(df-index-range (df data-frame?) (series string?) (value any/c))
+         (cons/c index/c index/c)]{
+Finds the leftmost and rightmost position of @racket[value], and return them
+respectively, in the data frame @racket[df]. This is useful for when a given
+series has multiple elements, and you want to find all of their occurrences.
+As the given series is sorted, this is a range, and not a collection of
+indices.
+
+The series must be sorted, see @racket[df-set-sorted!], otherwise the calls
+will raise an error.
+
+All other edge cases are the same as @racket[df-index-of].
 }
 
 @deftogether[(

--- a/scribblings/data-frame.scrbl
+++ b/scribblings/data-frame.scrbl
@@ -115,13 +115,6 @@ the data series, except NA values must satisfy this contract.
 
 }
 
-@defproc[(df-shallow-copy [df data-frame?]) data-frame]{
-  Creates a copy of @racket[df]. The returned copy will reference the
-  same data series objects as the original (and the properties), but any
-  add/delete operations, for both series and properties, will only affect
-  the copy.
-}
-
 @defproc[(df-add-series! (df data-frame?) (series series?)) any/c]{
 Add a new series to the data frame.  If the data frame is empty, the
 series can have any number of elements, otherwise it must have the
@@ -155,6 +148,15 @@ names.
 
 }
 
+@defproc[(df-duplicate-series (df data-frame?) (name string?)) series?]{
+Duplicates the series with name @racket[name] in the data-frame
+@racket[df]. The internal contents of the series are the same, but any
+add/delete operations and blessings will only affect the copy.
+
+If the series with name @racket[name] is delayed
+(see @racket[df-add-lazy!]), this will force it.
+}
+
 @defproc[(df-set-sorted! (df data-frame?) (name string?) (cmpfn (or/c
            #f (-> any/c any/c boolean?)))) any/c]{
 
@@ -175,6 +177,13 @@ Set the contract for values in the data frame @racket[df] series
 all values in the series match @racket[contractfn] or are NA.  The
 @racket[contractfn] need not return @racket[#t] for the NA value.
 
+}
+
+@defproc[(df-shallow-copy [df data-frame?]) data-frame]{
+  Creates a copy of @racket[df]. The returned copy will reference the
+  same data series objects as the original (and the properties), but any
+  add/delete operations, for both series and properties, will only affect
+  the copy.
 }
 
 @defform[(for/data-frame (series-name ...) body-or-break ... body)]{

--- a/scribblings/data-frame.scrbl
+++ b/scribblings/data-frame.scrbl
@@ -428,6 +428,16 @@ value, which is a list with all the values from the selected
 
 }
 
+@defproc[(df-is-sorted? (df data-frame?) (series string?)) boolean?]{
+Determines if the given series @racket[series] in the data-frame @racket[df]
+is sorted. Useful for programatically determining whether further manipulation
+is needed before running @racket[df-index-of], or for knowing when linear
+search is necessary.
+
+This does not check whether the series is actually sorted, rather whether it
+has been blessed with @racket[df-set-sorted!].
+}
+
 @deftogether[(                        
 @defproc[(df-index-of (df data-frame?) (series string?) (value any/c)) index/c]
 @defproc[(df-index-of* (df data-frame?) (series string?) (value any/c) ...) (listof index/c)])]{

--- a/scribblings/data-frame.scrbl
+++ b/scribblings/data-frame.scrbl
@@ -150,8 +150,7 @@ names.
 
 @defproc[(df-duplicate-series (df data-frame?) (name string?)) series?]{
 Duplicates the series with name @racket[name] in the data-frame
-@racket[df]. The internal contents of the series are the same, but any
-add/delete operations and blessings will only affect the copy.
+@racket[df]. The resulting copy will not impact the original.
 
 If the series with name @racket[name] is delayed
 (see @racket[df-add-lazy!]), this will force it.

--- a/scribblings/data-frame.scrbl
+++ b/scribblings/data-frame.scrbl
@@ -186,7 +186,7 @@ all values in the series match @racket[contractfn] or are NA.  The
   the copy.
 }
 
-@defform[(for/data-frame (series-name ...) body-or-break ... body)]{
+@defform[(for/data-frame (series-name ...) (for-clause ...) body-or-break ... body)]{
 Constructs a new data-frame with the given @racket[series-name]s,
 row-by-row.
 
@@ -205,7 +205,7 @@ Each iteration must have the same contract.
 ]
 }
 
-@defform[(for*/data-frame (series-name ...) body-or-break ... body)]{
+@defform[(for*/data-frame (series-name ...) (for-clause ...) body-or-break ... body)]{
 Like @racket[for/data-frame], but iterates like @racket[for*].
 
 @examples[#:eval ev

--- a/scribblings/data-frame.scrbl
+++ b/scribblings/data-frame.scrbl
@@ -438,12 +438,8 @@ value, which is a list with all the values from the selected
 
 @defproc[(df-is-sorted? (df data-frame?) (series string?)) boolean?]{
 Determines if the given series @racket[series] in the data-frame @racket[df]
-is sorted. Useful for programatically determining whether further manipulation
-is needed before running @racket[df-index-of], or for knowing when linear
-search is necessary.
-
-This does not check whether the series is actually sorted, rather whether it
-has been blessed with @racket[df-set-sorted!].
+is sorted (i.e. @racket[df-set-sorted!] has been called and succeeded for this
+series).
 }
 
 @deftogether[(                        
@@ -468,18 +464,22 @@ all the values in @racket[series].
 
 }
 
-@defproc[(df-index-range (df data-frame?) (series string?) (value any/c))
-         (cons/c index/c index/c)]{
-Finds the leftmost and rightmost position of @racket[value], and return them
-respectively, in the data frame @racket[df]. This is useful for when a given
-series has multiple elements, and you want to find all of their occurrences.
-As the given series is sorted, this is a range, and not a collection of
-indices.
+@defproc[(df-equal-range (df data-frame?) (series string?) (value any/c))
+         (values index/c index/c)]{
+Finds the lower bound of appearance (inclusive) and upper bound of appearance
+(exclusive) of @racket[value], and return them respectively, in the data frame
+@racket[df]. This is useful for when a given series has multiple elements, and
+you want to find all of their occurrences. As the given series must be sorted,
+this is a range, and not a collection of indices.
 
-The series must be sorted, see @racket[df-set-sorted!], otherwise the calls
-will raise an error.
+The series must be sorted (see @racket[df-set-sorted!]), or else this will
+error.
 
-All other edge cases are the same as @racket[df-index-of].
+The given @racket[value] need not be present in the @racket[series]. If this is
+the case, the lower bound is the position of the first element which comes before
+@racket[value], according to the sort function, and the upper bound is the first
+element which comes after @racket[value]. This is the range in which the given
+value could be inserted and keep the series sorted.
 }
 
 @deftogether[(


### PR DESCRIPTION
This adds a few utility functions, and therefore closes #8.

Changes to existing functions:
- `bsearch` now has a `#:rightmost?` argument, which determines whether to get the index of the rightmost element in the vector, rather than the leftmost one. necessary for `series-index-range`

New functions:
- `series-index-range`: binary searches on a series, and returns both the left and rightmost index of an element. useful for when a series has duplicates
- `df-index-range`: same for data-frames
- `series-is-sorted?`: determines if a series has a comparison function. useful for knowing whether `series-index-of` is possible, or sorting/linear search is required
- `df-is-sorted?`: same for data-frames
- `series-shallow-copy`: copies a series's vector, retaining all of its properties
- `df-duplicate-series`: returns a copy of the given series from the data-frame, retaining all of its properties, using `series-shallow-copy`

Nit-picks:
- added `df-shallow-copy` to docs
- fixed `for/data-frame` syntax in docs (call that cleaning up my own mess)

All functions have tests, but do feel free to let me know if they're insufficient.